### PR TITLE
Disable import plugin checks in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,11 @@ engines:
   eslint:
     enabled: true
     channel: "eslint-3"
+    checks:
+      import/no-unresolved:
+        enabled: false
+      import/extensions:
+        enabled: false
   fixme:
     enabled: true
 ratings:


### PR DESCRIPTION
They don't install node_modules so it cannot ever work.