### PR TITLE
Run CI test for Node v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "7"
   - "6"
   - "5"
   - "4"


### PR DESCRIPTION
Failing because `buble` doesn't support Node7 ... https://gitlab.com/Rich-Harris/buble/issues/141